### PR TITLE
Add `StateSpaceEconMTKExt` docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 FAME = "0.3"
 ModelBaseEcon = "0.6"
 StateSpaceEcon = "0.5"
-TimeSeriesEcon = "0.6"
+TimeSeriesEcon = "0.7"
 julia = "1.7"
 
 [extras]

--- a/makedocs.jl
+++ b/makedocs.jl
@@ -31,6 +31,7 @@ makedocs(
             "TimeSeriesEcon" => "Reference/TimeSeriesEcon.md",
             "ModelBaseEcon" => "Reference/ModelBaseEcon.md",
             "StateSpaceEcon" => "Reference/StateSpaceEcon.md",
+            "StateSpaceEcon ModelingToolkit Extension" => "Reference/StateSpaceEconMTKExt.md",
             "FAME" => "Reference/FAME.md",
         ],
         "Design Papers" => [

--- a/src/Reference/StateSpaceEconMTKExt.md
+++ b/src/Reference/StateSpaceEconMTKExt.md
@@ -1,0 +1,19 @@
+# StateSpaceEcon ModelingToolkit Extension Reference
+
+```@contents
+Pages = ["statespaceeconmtkext.md"]
+```
+
+### Public Interface
+
+```@autodocs
+Modules = [StateSpaceEcon.MTKExt]
+Private = false
+```
+
+### Internals
+
+```@autodocs
+Modules = [StateSpaceEcon.MTKExt]
+Public = false
+```


### PR DESCRIPTION
This PR adds docs for the ModelingToolkit extension added in bankofcanada/StateSpaceEcon.jl#61.

I had to bump the compat for TimeSeriesEcon because I was having compat issues when using my branch of StateSpaceEcon (branched off of `master`).

Note: This should not be merged until the above-mentioned PR is merged.